### PR TITLE
Funzionalità archivio: commenti con URL e ancora 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+*.pyc
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+*.coverage
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+*.orig
+
+# Directories #
+###############

--- a/HOOKIIFIER/hookiifier.py
+++ b/HOOKIIFIER/hookiifier.py
@@ -15,6 +15,9 @@ import os
 import time
 import re
 import codecs
+libs = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(libs)
+from utils import *
 
 # Globals
 debug = False
@@ -91,7 +94,7 @@ def getarticle() :
         # Print article
         farticle = createfile('%s.html' % pname)
         print_article(farticle, ptitle, pdate, pcontent, pcount, pname)
-        getcomments(farticle, pid, 0, 0)
+        getcomments(farticle, pid, 0, 0, pname)
         print_article_close(farticle)
 
     print_index_close(findex)
@@ -101,7 +104,7 @@ def getarticle() :
         renameindexfile("index.workinprogress.html", "index.html")
 
 
-def getcomments(f, post, cid, indent) :
+def getcomments(f, post, cid, indent, pname) :
     global db
 
     indent += 1
@@ -120,8 +123,8 @@ def getcomments(f, post, cid, indent) :
         return
 
     for (cid, cdate, cauthor, ccontent, cparent, cpauthor) in cur.fetchall() :
-        print_comment(f, indent, cid, cdate, cauthor, ccontent, cparent, cpauthor)
-        getcomments(f, post, cid, indent)
+        print_comment(f, indent, cid, cdate, cauthor, ccontent, cparent, cpauthor, pname)
+        getcomments(f, post, cid, indent, pname)
 
 
 def debug_query() :
@@ -272,13 +275,16 @@ def print_footer(f) :
     f.close()
 
 
-def print_comment(f, indent, cid, cdate, cauthor, ccontent, cparent, cpauthor) :
+def print_comment(f, indent, cid, cdate, cauthor, ccontent, cparent, cpauthor, pname) :
     w = indent * 20
     print >> f, '<div style="margin-left:%dpx; margin-right:-%dx; width:600px;">' % (w, w)
+    timestamp = datetimestr_to_timestamp(repr(cdate))
+    nickname = normalized_nickname(cauthor)
+    url_tag =  "<a href=\"http://www.hookii.it/%s#%s%d>" % (pname, "" if nickname is None else nickname, timestamp)
     if (cauthor == cpauthor) :
-            print >> f, "<h3>", cauthor, "- <font size='2'>", cdate, "</font></h3>"
+            print >> f, "<h3>", url_tag, cauthor, "- <font size='2'>", cdate, "</font></a></h3>"
     else :
-            print >> f, "<h3>", cauthor, "@ %s" % cpauthor, "- <font size='2'>", cdate, "</font></h3>"
+            print >> f, "<h3>", url_tag, cauthor, "@ %s" % cpauthor, "- <font size='2'>", cdate, "</font></a></h3>"
 
     #ccontent = embed_image(ccontent)
     ccontent = embed_all(ccontent)

--- a/HOOKIIFIER/hookiifier.py
+++ b/HOOKIIFIER/hookiifier.py
@@ -123,7 +123,7 @@ def getcomments(f, post, cid, indent, pname) :
         return
 
     for (cid, cdate, cauthor, ccontent, cparent, cpauthor) in cur.fetchall() :
-        print_comment(f, indent, cid, cdate, cauthor, ccontent, cparent, cpauthor, pname)
+        print_comment(f, indent, cdate, cauthor, ccontent, cpauthor, pname)
         getcomments(f, post, cid, indent, pname)
 
 
@@ -275,12 +275,12 @@ def print_footer(f) :
     f.close()
 
 
-def print_comment(f, indent, cid, cdate, cauthor, ccontent, cparent, cpauthor, pname) :
+def print_comment(f, indent, cdate, cauthor, ccontent, cpauthor, pname) :
     w = indent * 20
     print >> f, '<div style="margin-left:%dpx; margin-right:-%dx; width:600px;">' % (w, w)
     timestamp = datetimestr_to_timestamp(repr(cdate))
     nickname = normalized_nickname(cauthor)
-    url_tag =  "<a href=\"http://www.hookii.it/%s#%s%d>" % (pname, "" if nickname is None else nickname, timestamp)
+    url_tag =  "<a href=\"http://www.hookii.it/%s#%s%d\">" % (pname, "" if nickname is None else nickname, timestamp)
     if (cauthor == cpauthor) :
             print >> f, "<h3>", url_tag, cauthor, "- <font size='2'>", cdate, "</font></a></h3>"
     else :

--- a/HOOKIIFIER/tests/utils_test.py
+++ b/HOOKIIFIER/tests/utils_test.py
@@ -40,7 +40,17 @@ class Utils(unittest.TestCase):
         res = normalized_nickname("Erni ♖")
         self.assertEqual(res, "Erni♖_")
         #print "Erni ♖ normalized nickname is: %s" % res
+    
+    def test_read_file_none(self):
+        self.assertIsNone(read_file(None))
         
+    def test_read_non_existing_file(self):
+        self.assertIsNone(read_file("bla"))
+    
+    def test_read_file_ok(self):
+        expected = "Can you read it?"
+        fpath = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', "test.txt"))
+        self.assertEqual(read_file(fpath), expected)
 
 if __name__ == "__main__":
 #     suite = unittest.TestLoader().loadTestsFromTestCase(Utils)

--- a/HOOKIIFIER/tests/utils_test.py
+++ b/HOOKIIFIER/tests/utils_test.py
@@ -22,6 +22,11 @@ class Utils(unittest.TestCase):
     def test_datetimestr_to_timestamp_invalid_arg(self):
         res = datetimestr_to_timestamp("bla")
         self.assertEqual(res, 0)
+        
+    def test_datetimestr_to_timestamp_ok(self):
+        res = datetimestr_to_timestamp("2015-06-12 23:08:00")
+        expected = 1434143280
+        self.assertEqual(res, expected)
 
 
 if __name__ == "__main__":

--- a/HOOKIIFIER/tests/utils_test.py
+++ b/HOOKIIFIER/tests/utils_test.py
@@ -1,0 +1,30 @@
+#!/bin/env python
+
+'''
+   Created on Jun 12, 2015
+   @author: s1m0n4
+   @copyright: 2015 s1m0n4 for hookii.it
+'''
+
+import unittest 
+import os
+import sys
+libs = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../'))
+sys.path.append(libs)
+from utils import datetimestr_to_timestamp
+
+class Utils(unittest.TestCase):
+
+    def test_datetimestr_to_timestamp_none_arg(self):
+        res = datetimestr_to_timestamp(None)
+        self.assertEqual(res, 0)
+
+    def test_datetimestr_to_timestamp_invalid_arg(self):
+        res = datetimestr_to_timestamp("bla")
+        self.assertEqual(res, 0)
+
+
+if __name__ == "__main__":
+#     suite = unittest.TestLoader().loadTestsFromTestCase(Utils)
+#     unittest.TextTestRunner(verbosity=2).run(suite)
+    unittest.main()

--- a/HOOKIIFIER/tests/utils_test.py
+++ b/HOOKIIFIER/tests/utils_test.py
@@ -1,5 +1,5 @@
 #!/bin/env python
-
+# -*- coding: utf-8 -*-
 '''
    Created on Jun 12, 2015
    @author: s1m0n4
@@ -11,7 +11,7 @@ import os
 import sys
 libs = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../'))
 sys.path.append(libs)
-from utils import datetimestr_to_timestamp
+from utils import *
 
 class Utils(unittest.TestCase):
 
@@ -27,7 +27,20 @@ class Utils(unittest.TestCase):
         res = datetimestr_to_timestamp("2015-06-12 23:08:00")
         expected = 1434143280
         self.assertEqual(res, expected)
-
+    
+    def test_normalized_nickname_none(self):
+        res = normalized_nickname(None)
+        self.assertIsNone(res)
+    
+    def test_normalized_nickname_empty(self):
+        res = normalized_nickname("     ")
+        self.assertIsNone(res)
+    
+    def test_normalized_nickname_nonasciichars(self):
+        res = normalized_nickname("Erni ♖")
+        self.assertEqual(res, "Erni♖_")
+        #print "Erni ♖ normalized nickname is: %s" % res
+        
 
 if __name__ == "__main__":
 #     suite = unittest.TestLoader().loadTestsFromTestCase(Utils)

--- a/HOOKIIFIER/utils.py
+++ b/HOOKIIFIER/utils.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+'''
+   Created on Jun 12, 2015
+   @author: s1m0n4
+   @copyright: 2015 s1m0n4 for hookii.it
+'''
+
+import time
+import os
+import sys
+libs = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(libs)
+
+
+def datetimestr_to_timestamp(dtstr):
+    dtstruct = None
+    try:
+        dtstruct = time.strptime(dtstr)
+        return time.mktime(dtstruct)
+    except Exception:
+        return 0

--- a/HOOKIIFIER/utils.py
+++ b/HOOKIIFIER/utils.py
@@ -32,3 +32,12 @@ def normalized_nickname(nickname):
     except Exception:
         return norm_nick
     return norm_nick + "_"
+
+def read_file(f):
+    result = None
+    if f is not None:
+        if os.path.exists(f):
+            if os.path.isfile(f):
+                with open(f, 'r+') as fo:
+                    result = fo.read()
+    return result

--- a/HOOKIIFIER/utils.py
+++ b/HOOKIIFIER/utils.py
@@ -20,3 +20,15 @@ def datetimestr_to_timestamp(dtstr):
         return time.mktime(dtstruct)
     except Exception:
         return 0
+    
+def normalized_nickname(nickname):
+    norm_nick = None
+    try:
+        norm_nick = nickname.replace(" ", "")
+        if len(norm_nick) > 19:
+            return norm_nick[:19] + "_"
+        if len(norm_nick) == 0:
+            return None
+    except Exception:
+        return norm_nick
+    return norm_nick + "_"

--- a/HOOKIIFIER/utils.py
+++ b/HOOKIIFIER/utils.py
@@ -16,7 +16,7 @@ sys.path.append(libs)
 def datetimestr_to_timestamp(dtstr):
     dtstruct = None
     try:
-        dtstruct = time.strptime(dtstr)
+        dtstruct = time.strptime(dtstr, "%Y-%m-%d %H:%M:%S")
         return time.mktime(dtstruct)
     except Exception:
         return 0


### PR DESCRIPTION
Ciao @ernitron ,

ho aggiunto l'URL ai commenti degli articoli dell'archivio in questo formato:
<url-articolo>#<user>_<timestamp>

Ho anche aggiunto test d'unità per le varie funzioni, purtroppo il test d'integrazione su hookiifier fallisce con un errore alla linea 331 di hookiifier.py
string = pattern_youtube.sub(replacement_string, originalstring)
AttributeError: 'str' object has no attribute 'sub'

pattern_youtube é una stringa. Che interpreter python usi?
Anche se mi manca il test d'integrazione la feature é pronta e dovrebbe funzionare a dovere.

Mi sono permessa anche di rimuovere gli args cid e cparent da print_comment, che non erano usati dal metodo. E ho aggiunto pname per poter passar il link all'articolo. 
